### PR TITLE
Improve Airflow parallelism

### DIFF
--- a/airflow/override-values.yaml
+++ b/airflow/override-values.yaml
@@ -14,6 +14,15 @@ config:
     smtp_mail_from: cbioportalpipelines@gmail.com
   core:
     allowed_deserialization_classes_regexp: airflow\..* .*\..*StudyBuilder
+
+    # For more information on Airflow performance, refer to:
+    # https://airflow.apache.org/docs/apache-airflow/stable/faq.html#how-to-improve-dag-performance
+    # Up to 500 tasks per scheduler, across all DAGs
+    parallelism: 500
+    # Up to 100 active tasks per DAG
+    max_active_tasks_per_dag: 100
+    # Up to 16 runs of the same DAG (this is the default)
+    max_active_runs_per_dag: 16
   webserver:
     base_url: https://airflow.cbioportal.dev.aws.mskcc.org
   kubernetes_executor:


### PR DESCRIPTION
By default, Airflow allows up to 32 tasks to run per scheduler across all DAGs, and up to 16 tasks to run concurrently for a given DAG. This PR increases those limits to 500 and 100, respectively.

/cc @callachennault