### PR TITLE
Enable Airflow API

### DIFF
--- a/airflow/override-values.yaml
+++ b/airflow/override-values.yaml
@@ -1,11 +1,16 @@
 webserverSecretKey: '3005d31b2366ac6fd4da0406c222d090'
 
 nodeSelector: 
-  eks.amazonaws.com/nodegroup: airflow-scaledup
+  eks.amazonaws.com/nodegroup: airflow-r5xlarge
 
 executor: KubernetesExecutor
 
 config:
+  api:
+    auth_backends: airflow.api.auth.backend.basic_auth
+    access_control_allow_headers: origin, content-type, accept
+    access_control_allow_methods: POST, GET, OPTIONS, DELETE
+    access_control_allow_origins: http://pipelines3.cbioportal.aws.mskcc.org
   smtp:
     smtp_host: smtp.gmail.com
     smtp_starttls: True

--- a/airflow/override-values.yaml
+++ b/airflow/override-values.yaml
@@ -53,6 +53,20 @@ webserver:
     timeoutSeconds: 360
 
 scheduler:
+  # To deploy multiple scheduler replicas across nodes, uncomment the below configuration 
+  #replicas: 2
+
+  #labels:
+    #pod-type: scheduler
+
+  #topologySpreadConstraints:
+    #- maxSkew: 1
+      #topologyKey: kubernetes.io/hostname
+      #whenUnsatisfiable: DoNotSchedule
+      #labelSelector:
+        #matchLabels:
+          #pod-type: scheduler
+
   extraVolumeMounts:
     - name: pv
       mountPath: /opt/airflow/git_repos
@@ -178,6 +192,7 @@ dags:
   # See: https://airflow.apache.org/docs/helm-chart/stable/manage-dags-files.html#mounting-dags-using-git-sync-sidecar-with-persistence-enabled
   persistence:
     enabled: true
+    storageClassName: efs-sc
   gitSync:
     enabled: true 
     repo: git@github.com:knowledgesystems/cdsi-airflow-dags.git 


### PR DESCRIPTION
This PR:

- Enables the Airflow REST API in conjunction with [this PR](https://github.com/knowledgesystems/cmo-pipelines/pull/1194) to trigger the S3 pull DAG via the API. Documentation reference: https://airflow.apache.org/docs/apache-airflow/stable/security/api.html, https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#operation/post_dag_run 
- Adds a template for deploying multiple schedulers
- Specifies the storage class name for the DAGs PVC, because otherwise the PVC is created with the default storage class which does not allow ReadWriteMany access. ReadWriteMany access is needed if deploying multiple schedulers - different scheduler pods need to read/write from the DAGs PVC.